### PR TITLE
Remove the system import for Python

### DIFF
--- a/reee.py
+++ b/reee.py
@@ -1,4 +1,3 @@
-import sys
-sys.stdout.write('r')
+print('r')
 while True:
-	sys.stdout.write('e')
+	print('e')


### PR DESCRIPTION
import sys is overkill here, far better to just use `print()`